### PR TITLE
Introduce `projectInfoVersion` key to control propagated version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Create a project info file in `project/project-info.conf` using HOCON format:
 
 ```hocon
 project-info {
-  # version is overridden with sbt's project version
+  # version is overridden from the `projectInfoVersion` key (which defaults to sbt's project version)
   version: "current"
   scala-versions: ["2.12", "2.13"]
   jdk-versions: ["OpenJDK 8"]

--- a/src/main/scala/com/lightbend/paradox/projectinfo/ParadoxProjectInfoPlugin.scala
+++ b/src/main/scala/com/lightbend/paradox/projectinfo/ParadoxProjectInfoPlugin.scala
@@ -24,6 +24,8 @@ import sbt.Keys._
 import sbt._
 
 object ParadoxProjectInfoPlugin extends AutoPlugin {
+  import ParadoxProjectInfoPluginKeys._
+
   object autoImport extends ParadoxProjectInfoPluginKeys
 
   override def requires: Plugins = ParadoxPlugin
@@ -33,6 +35,7 @@ object ParadoxProjectInfoPlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[_]] = projectInfoSettings(Compile)
 
   def projectInfoGlobalSettings: Seq[Setting[_]] = Seq(
+    projectInfoVersion := version.value,
     paradoxDirectives ++= Def.taskDyn {
       Def.task {
         val s = state.value
@@ -42,7 +45,7 @@ object ParadoxProjectInfoPlugin extends AutoPlugin {
               val f = new File((LocalRootProject / baseDirectory).value, "project/project-info.conf")
               if (f.exists()) {
                 val extracted   = Project.extract(s)
-                val rootVersion = extracted.get(version)
+                val rootVersion = extracted.get(projectInfoVersion)
                 val config = ConfigFactory
                   .parseFile(f)
                   // inject into config before resolving

--- a/src/main/scala/com/lightbend/paradox/projectinfo/ParadoxProjectInfoPluginKeys.scala
+++ b/src/main/scala/com/lightbend/paradox/projectinfo/ParadoxProjectInfoPluginKeys.scala
@@ -18,4 +18,8 @@ package com.lightbend.paradox.projectinfo
 
 import sbt._
 
-trait ParadoxProjectInfoPluginKeys {}
+trait ParadoxProjectInfoPluginKeys {
+  val projectInfoVersion = settingKey[String]("The version/revision propagated into `project.info.version`.")
+}
+
+object ParadoxProjectInfoPluginKeys extends ParadoxProjectInfoPluginKeys

--- a/src/sbt-test/project-info/explicit-version/build.sbt
+++ b/src/sbt-test/project-info/explicit-version/build.sbt
@@ -1,0 +1,22 @@
+import sbt.Keys.{homepage, scmInfo}
+
+enablePlugins(ParadoxPlugin)
+paradoxTheme := None
+
+version in ThisBuild := "0.1.2.3"
+projectInfoVersion   := "snapshot"
+
+val commonSettings = Seq(
+  organization := "com.lightbend",
+  licenses     := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")),
+  homepage     := Some(url("https://github.com/lightbend/sbt-paradox-project-info")),
+  scmInfo := Some(
+    ScmInfo(url("https://github.com/lightbend/sbt-paradox-project-info"),
+            "git@github.com:lightbend/sbt-paradox-project-info.git")),
+)
+
+lazy val core = Project(id = "coreId", base = file("core"))
+  .settings(commonSettings)
+  .settings(
+    crossScalaVersions := Seq("2.12.7", "2.11.12"),
+  )

--- a/src/sbt-test/project-info/explicit-version/expected/index.html
+++ b/src/sbt-test/project-info/explicit-version/expected/index.html
@@ -1,0 +1,28 @@
+<p>The project information:</p>
+<table class="project-info">
+<tr><th colspan=2>Project Info: The core project</th></tr>
+  <tr><th>Artifact</th><td><div>com.lightbend</div>
+  <div>coreId</div>
+  <div>0.1.2.3</div>
+  <div><a href="snapshots.html">Snapshots are available</a></div>
+  </td></tr>
+  <tr><th>JDK versions</th><td><div>OpenJDK 8</div></td></tr>
+  <tr><th>Scala versions</th><td>2.12.7, 2.11.12</td></tr>
+  <tr><th>JPMS module name</th><td>alpakka.core</td></tr>
+  <tr><th>License</th><td><div><a href="http://opensource.org/licenses/Apache-2.0" target="_blank" rel="noopener noreferrer">Apache-2.0</a></div>
+  </td></tr>
+  <tr><th>Readiness level</th><td><div class='readiness-level'><a href="https://developer.lightbend.com/docs/reactive-platform/2.0/support-terminology/index.html#supported" target="_blank" rel="noopener noreferrer">Supported</a>, <a href="https://www.lightbend.com/subscription" target="_blank">Lightbend Subscription</a> provides support</div>
+  <div>Since 0.22, 2018-11-22</div>
+  </td></tr>
+  <tr><th>Home page</th><td><a href="https://github.com/lightbend/sbt-paradox-project-info">https://github.com/lightbend/sbt-paradox-project-info</a></td></tr>
+  <tr><th>API documentation</th><td>
+  <div><a href="https://developer.lightbend.com/docs/api/alpakka/snapshot/akka/stream/alpakka/index.html" target="_blank" rel="noopener noreferrer">Scaladoc</a></div>
+  </td></tr>
+  <tr><th>Forums</th><td>
+  <div><a href="https://discuss.lightbend.com/c/akka/" target="_blank" rel="noopener noreferrer">Lightbend Discuss</a></div>
+  <div><a href="https://gitter.im/akka/alpakka-kafka" target="_blank" rel="noopener noreferrer">akka/alpakka-kafka Gitter channel</a></div>
+  </td></tr>
+  <tr><th>Release notes</th><td><a href="https://github.com/lightbend/sbt-paradox-project-info/releases" target="_blank" rel="noopener noreferrer">Github releases</a></td></tr>
+  <tr><th>Issues</th><td><a href="https://github.com/lightbend/sbt-paradox-project-info/issues" target="_blank" rel="noopener noreferrer">Github issues</a></td></tr>
+  <tr><th>Sources</th><td><a href="https://github.com/lightbend/sbt-paradox-project-info" target="_blank" rel="noopener noreferrer">https://github.com/lightbend/sbt-paradox-project-info</a></td></tr>
+</table>

--- a/src/sbt-test/project-info/explicit-version/project/build.properties
+++ b/src/sbt-test/project-info/explicit-version/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.6

--- a/src/sbt-test/project-info/explicit-version/project/plugins.sbt
+++ b/src/sbt-test/project-info/explicit-version/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % sys.props("project.version"))

--- a/src/sbt-test/project-info/explicit-version/project/project-info.conf
+++ b/src/sbt-test/project-info/explicit-version/project/project-info.conf
@@ -1,0 +1,52 @@
+project-info {
+  version: "current"
+  shared-info {
+    jdk-versions: ["OpenJDK 8"]
+    issues: {
+      url: "https://github.com/lightbend/sbt-paradox-project-info/issues"
+      text: "Github issues"
+    }
+    release-notes: {
+      url: "https://github.com/lightbend/sbt-paradox-project-info/releases"
+      text: "Github releases"
+    }
+  }
+  coreId: ${project-info.shared-info} {
+    title: "The core project"
+    jpms-name: "alpakka.core"
+    snapshots: {
+      text: "Snapshots are available"
+      url: "snapshots.html"
+      new-tab: false
+    }
+    levels: [
+      {
+        readiness: Supported
+        since: "2018-11-22"
+        since-version: "0.22"
+      }
+      {
+        readiness: Incubating
+        since: "2018-08-22"
+        since-version: "0.16"
+        note: "Community rocks this module"
+      }
+    ]
+    api-docs: [
+      {
+        text: "Scaladoc"
+        url: "https://developer.lightbend.com/docs/api/alpakka/"${project-info.version}"/akka/stream/alpakka/index.html"
+      }
+    ]
+    forums: [
+      {
+        text: "Lightbend Discuss"
+        url: "https://discuss.lightbend.com/c/akka/"
+      }
+      {
+        text: "akka/alpakka-kafka Gitter channel"
+        url: "https://gitter.im/akka/alpakka-kafka"
+      }
+    ]
+  }
+}

--- a/src/sbt-test/project-info/explicit-version/src/main/paradox/_template/page.st
+++ b/src/sbt-test/project-info/explicit-version/src/main/paradox/_template/page.st
@@ -1,0 +1,1 @@
+$page.content$

--- a/src/sbt-test/project-info/explicit-version/src/main/paradox/index.md
+++ b/src/sbt-test/project-info/explicit-version/src/main/paradox/index.md
@@ -1,0 +1,3 @@
+The project information:
+
+@@project-info { projectId="coreId" }

--- a/src/sbt-test/project-info/explicit-version/test
+++ b/src/sbt-test/project-info/explicit-version/test
@@ -1,0 +1,3 @@
+> paradox
+
+$ must-mirror target/paradox/site/main/index.html expected/index.html


### PR DESCRIPTION
This is important when the version is used as part of links and may need to be reformatted or changed (eg. to "snapshot").