### PR TITLE
Update and apply scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,10 +1,10 @@
-version = 1.5.1
-
+version = 3.4.3
+runner.dialect = scala213
 maxColumn = 120
-docstrings = JavaDoc
+docstrings.style = Asterisk
 assumeStandardLibraryStripMargin = true
 rewrite.rules = [RedundantBraces, RedundantParens, SortImports, SortModifiers]
-unindentTopLevelOperators = true
+indentOperator.exemptScope = all
 align.tokens = [
   {code = "%", owner = "Term.ApplyInfix"},
   {code = "%%", owner = "Term.ApplyInfix"},

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ sbtPlugin := true
 enablePlugins(SbtPlugin)
 import scala.collection.JavaConverters._
 scriptedLaunchOpts += ("-Dproject.version=" + version.value)
-scriptedLaunchOpts ++= java.lang.management.ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.filter(
-  a => Seq("-Xmx", "-Xms", "-XX", "-Dfile").exists(a.startsWith)
+scriptedLaunchOpts ++= java.lang.management.ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.filter(a =>
+  Seq("-Xmx", "-Xms", "-XX", "-Dfile").exists(a.startsWith)
 )
 
 crossSbtVersions := List("1.1.0")
@@ -16,15 +16,18 @@ name             := "sbt-paradox-project-info"
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.4.3")
 
 libraryDependencies ++= Seq(
-  "com.typesafe"  % "config"     % "1.3.3",
+  "com.typesafe"   % "config"    % "1.3.3",
   "org.scalatest" %% "scalatest" % "3.0.8" % Test // ApacheV2
 )
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 homepage := Some(url("https://github.com/lightbend/sbt-paradox-project-info"))
 scmInfo := Some(
-  ScmInfo(url("https://github.com/lightbend/sbt-paradox-project-info"),
-          "git@github.com:lightbend/sbt-paradox-project-info.git"))
+  ScmInfo(
+    url("https://github.com/lightbend/sbt-paradox-project-info"),
+    "git@github.com:lightbend/sbt-paradox-project-info.git"
+  )
+)
 developers += Developer(
   "contributors",
   "Contributors",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.dwijnand"      % "sbt-dynver"   % "4.0.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray"  % "0.5.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.6.0")
-addSbtPlugin("org.scalameta"     % "sbt-scalafmt" % "2.3.2")
+addSbtPlugin("org.scalameta"     % "sbt-scalafmt" % "2.4.6")

--- a/src/main/scala/com/lightbend/paradox/projectinfo/ProjectInfoDirective.scala
+++ b/src/main/scala/com/lightbend/paradox/projectinfo/ProjectInfoDirective.scala
@@ -67,11 +67,10 @@ object ProjectInfoDirective {
       .print("<div>")
       .print(sbtValues.version)
       .print("</div>")
-    snapshots.foreach {
-      case Link(url, text, newTab) =>
-        p.println().print("<div>")
-        printLink(p, url, text.getOrElse("Snapshots"), newTab)
-        p.print("</div>").println()
+    snapshots.foreach { case Link(url, text, newTab) =>
+      p.println().print("<div>")
+      printLink(p, url, text.getOrElse("Snapshots"), newTab)
+      p.print("</div>").println()
     }
     p.print("</td></tr>")
       .println()
@@ -130,35 +129,31 @@ object ProjectInfoDirective {
     }
     if (apiDocs.nonEmpty) {
       p.println().print("<tr><th>API documentation</th><td>")
-      apiDocs.foreach {
-        case Link(url, text, newTab) =>
-          p.println().print("<div>")
-          printLink(p, url, text.getOrElse("API"), newTab)
-          p.print("</div>")
+      apiDocs.foreach { case Link(url, text, newTab) =>
+        p.println().print("<div>")
+        printLink(p, url, text.getOrElse("API"), newTab)
+        p.print("</div>")
       }
       p.println().print("</td></tr>")
     }
     if (forums.nonEmpty) {
       p.println().print("<tr><th>Forums</th><td>")
-      forums.foreach {
-        case Link(url, text, newTab) =>
-          p.println().print("<div>")
-          printLink(p, url, text.getOrElse("Forum"), newTab)
-          p.print("</div>")
+      forums.foreach { case Link(url, text, newTab) =>
+        p.println().print("<div>")
+        printLink(p, url, text.getOrElse("Forum"), newTab)
+        p.print("</div>")
       }
       p.println().print("</td></tr>")
     }
-    releaseNotes.foreach {
-      case Link(url, text, newTab) =>
-        p.println().print("<tr><th>Release notes</th><td>")
-        printLink(p, url, text.getOrElse("Release notes"), newTab)
-        p.print("</td></tr>")
+    releaseNotes.foreach { case Link(url, text, newTab) =>
+      p.println().print("<tr><th>Release notes</th><td>")
+      printLink(p, url, text.getOrElse("Release notes"), newTab)
+      p.print("</td></tr>")
     }
-    issues.foreach {
-      case Link(url, text, newTab) =>
-        p.println().print("<tr><th>Issues</th><td>")
-        printLink(p, url, text.getOrElse("Issue tracker"), newTab)
-        p.print("</td></tr>")
+    issues.foreach { case Link(url, text, newTab) =>
+      p.println().print("<tr><th>Issues</th><td>")
+      printLink(p, url, text.getOrElse("Issue tracker"), newTab)
+      p.print("</td></tr>")
     }
     sbtValues.scmInfo.foreach { scmInfo =>
       p.println().print("<tr><th>Sources</th><td>")

--- a/src/main/scala/com/lightbend/paradox/projectinfo/model.scala
+++ b/src/main/scala/com/lightbend/paradox/projectinfo/model.scala
@@ -25,13 +25,15 @@ import com.typesafe.config.{Config, ConfigFactory}
 import scala.collection.immutable
 import scala.collection.JavaConverters._
 
-case class SbtValues(artifact: String,
-                     version: String,
-                     organization: String,
-                     homepage: Option[sbt.URL],
-                     scmInfo: Option[sbt.librarymanagement.ScmInfo],
-                     licenses: immutable.Seq[(String, sbt.URL)],
-                     crossScalaVersions: immutable.Seq[String])
+case class SbtValues(
+    artifact: String,
+    version: String,
+    organization: String,
+    homepage: Option[sbt.URL],
+    scmInfo: Option[sbt.librarymanagement.ScmInfo],
+    licenses: immutable.Seq[(String, sbt.URL)],
+    crossScalaVersions: immutable.Seq[String]
+)
 
 trait ReadinessLevel { def name: String }
 object ReadinessLevel {
@@ -40,7 +42,10 @@ object ReadinessLevel {
 
   case object Supported extends ReadinessLevel {
     val name =
-      s"""${glossary("supported", "Supported")}, <a href="https://www.lightbend.com/lightbend-subscription" target="_blank" rel="noopener">Lightbend Subscription</a> provides support"""
+      s"""${glossary(
+          "supported",
+          "Supported"
+        )}, <a href="https://www.lightbend.com/lightbend-subscription" target="_blank" rel="noopener">Lightbend Subscription</a> provides support"""
   }
   case object Certified extends ReadinessLevel {
     val name =
@@ -79,11 +84,13 @@ object Link {
   }
 }
 
-case class Level(level: ReadinessLevel,
-                 since: LocalDate,
-                 sinceVersion: String,
-                 ends: Option[LocalDate],
-                 note: Option[String])
+case class Level(
+    level: ReadinessLevel,
+    since: LocalDate,
+    sinceVersion: String,
+    ends: Option[LocalDate],
+    note: Option[String]
+)
 
 object Level {
 
@@ -98,17 +105,19 @@ object Level {
   }
 }
 
-case class ProjectInfo(name: String,
-                       title: String,
-                       scalaVersions: immutable.Seq[String],
-                       jdkVersions: immutable.Seq[String],
-                       jpmsName: Option[String],
-                       issues: Option[Link],
-                       apiDocs: immutable.Seq[Link],
-                       forums: immutable.Seq[Link],
-                       releaseNotes: Option[Link],
-                       snapshots: Option[Link],
-                       levels: immutable.Seq[Level])
+case class ProjectInfo(
+    name: String,
+    title: String,
+    scalaVersions: immutable.Seq[String],
+    jdkVersions: immutable.Seq[String],
+    jpmsName: Option[String],
+    issues: Option[Link],
+    apiDocs: immutable.Seq[Link],
+    forums: immutable.Seq[Link],
+    releaseNotes: Option[Link],
+    snapshots: Option[Link],
+    levels: immutable.Seq[Level]
+)
 
 object ProjectInfo {
   import Util.ExtendedConfig
@@ -126,24 +135,25 @@ object ProjectInfo {
     val releaseNotes = c.getOption("release-notes", (c, s) => Link(c.getConfig(s)))
     val snapshots    = c.getOption("snapshots", (c, s) => Link(c.getConfig(s)))
     val levels = c
-      .getOption("levels", (config, string) => {
-        for { item <- config.getObjectList(string).asScala.toList } yield {
-          Level(item.toConfig)
-        }
-      })
+      .getOption(
+        "levels",
+        (config, string) => for { item <- config.getObjectList(string).asScala.toList } yield Level(item.toConfig)
+      )
       .getOrElse(List.empty)
 
-    new ProjectInfo(name,
-                    title,
-                    scalaVersions,
-                    jdkVersions,
-                    jpmsName,
-                    issues,
-                    apiDocs,
-                    forums,
-                    releaseNotes,
-                    snapshots,
-                    levels)
+    new ProjectInfo(
+      name,
+      title,
+      scalaVersions,
+      jdkVersions,
+      jpmsName,
+      issues,
+      apiDocs,
+      forums,
+      releaseNotes,
+      snapshots,
+      levels
+    )
   }
 }
 
@@ -161,9 +171,7 @@ object Util {
       if (c.hasPath(path)) c.getBoolean(path) else defaultValue
     def getParsedList[T](path: String, read: Config => T): List[T] =
       if (c.hasPath(path)) {
-        for (cObj <- c.getObjectList(path).asScala.toList) yield {
-          read(cObj.toConfig)
-        }
+        for (cObj <- c.getObjectList(path).asScala.toList) yield read(cObj.toConfig)
       } else List.empty
   }
 }

--- a/src/sbt-test/project-info/explicit-version/build.sbt
+++ b/src/sbt-test/project-info/explicit-version/build.sbt
@@ -11,12 +11,15 @@ val commonSettings = Seq(
   licenses     := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")),
   homepage     := Some(url("https://github.com/lightbend/sbt-paradox-project-info")),
   scmInfo := Some(
-    ScmInfo(url("https://github.com/lightbend/sbt-paradox-project-info"),
-            "git@github.com:lightbend/sbt-paradox-project-info.git")),
+    ScmInfo(
+      url("https://github.com/lightbend/sbt-paradox-project-info"),
+      "git@github.com:lightbend/sbt-paradox-project-info.git"
+    )
+  )
 )
 
 lazy val core = Project(id = "coreId", base = file("core"))
   .settings(commonSettings)
   .settings(
-    crossScalaVersions := Seq("2.12.7", "2.11.12"),
+    crossScalaVersions := Seq("2.12.7", "2.11.12")
   )

--- a/src/sbt-test/project-info/happy-path/build.sbt
+++ b/src/sbt-test/project-info/happy-path/build.sbt
@@ -4,11 +4,14 @@ paradoxTheme := None
 
 val commonSettings = Seq(
   organization := "com.lightbend",
-  licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")),
-  homepage := Some(url("https://github.com/lightbend/sbt-paradox-project-info")),
+  licenses     := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")),
+  homepage     := Some(url("https://github.com/lightbend/sbt-paradox-project-info")),
   scmInfo := Some(
-    ScmInfo(url("https://github.com/lightbend/sbt-paradox-project-info"),
-            "git@github.com:lightbend/sbt-paradox-project-info.git")),
+    ScmInfo(
+      url("https://github.com/lightbend/sbt-paradox-project-info"),
+      "git@github.com:lightbend/sbt-paradox-project-info.git"
+    )
+  )
 )
 
 lazy val core = Project(id = "coreId", base = file("core"))

--- a/src/sbt-test/project-info/no-project-info-but-directive/build.sbt
+++ b/src/sbt-test/project-info/no-project-info-but-directive/build.sbt
@@ -4,11 +4,14 @@ paradoxTheme := None
 
 val commonSettings = Seq(
   organization := "com.lightbend",
-  licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")),
-  homepage := Some(url("https://github.com/lightbend/sbt-paradox-project-info")),
+  licenses     := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")),
+  homepage     := Some(url("https://github.com/lightbend/sbt-paradox-project-info")),
   scmInfo := Some(
-    ScmInfo(url("https://github.com/lightbend/sbt-paradox-project-info"),
-            "git@github.com:lightbend/sbt-paradox-project-info.git")),
+    ScmInfo(
+      url("https://github.com/lightbend/sbt-paradox-project-info"),
+      "git@github.com:lightbend/sbt-paradox-project-info.git"
+    )
+  )
 )
 
 lazy val core = Project(id = "coreId", base = file("core"))

--- a/src/sbt-test/project-info/no-project-info/build.sbt
+++ b/src/sbt-test/project-info/no-project-info/build.sbt
@@ -4,11 +4,14 @@ paradoxTheme := None
 
 val commonSettings = Seq(
   organization := "com.lightbend",
-  licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")),
-  homepage := Some(url("https://github.com/lightbend/sbt-paradox-project-info")),
+  licenses     := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")),
+  homepage     := Some(url("https://github.com/lightbend/sbt-paradox-project-info")),
   scmInfo := Some(
-    ScmInfo(url("https://github.com/lightbend/sbt-paradox-project-info"),
-            "git@github.com:lightbend/sbt-paradox-project-info.git")),
+    ScmInfo(
+      url("https://github.com/lightbend/sbt-paradox-project-info"),
+      "git@github.com:lightbend/sbt-paradox-project-info.git"
+    )
+  )
 )
 
 lazy val core = Project(id = "coreId", base = file("core"))

--- a/src/test/scala/com/lightbend/paradox/projectinfo/ProjectInfoSpec.scala
+++ b/src/test/scala/com/lightbend/paradox/projectinfo/ProjectInfoSpec.scala
@@ -57,14 +57,14 @@ class ProjectInfoSpec extends WordSpec with Matchers {
           "core",
           "core",
           scalaVersions = List("2.12", "2.13"),
-          jdkVersions   = List("OpenJDK 8"),
+          jdkVersions = List("OpenJDK 8"),
           Some("alpakka.core"),
-          issues       = None,
-          apiDocs      = immutable.Seq.empty,
-          forums       = immutable.Seq.empty,
+          issues = None,
+          apiDocs = immutable.Seq.empty,
+          forums = immutable.Seq.empty,
           releaseNotes = None,
-          snapshots    = None,
-          levels       = List()
+          snapshots = None,
+          levels = List()
         )
       )
     }
@@ -97,22 +97,26 @@ class ProjectInfoSpec extends WordSpec with Matchers {
       ProjectInfo(name, conf) should be(
         ProjectInfo(
           "core",
-          title         = "The core project",
+          title = "The core project",
           scalaVersions = List("2.12", "2.13"),
-          jdkVersions   = List("OpenJDK 8"),
+          jdkVersions = List("OpenJDK 8"),
           Some("alpakka.core"),
-          issues       = None,
-          apiDocs      = immutable.Seq.empty,
-          forums       = immutable.Seq.empty,
+          issues = None,
+          apiDocs = immutable.Seq.empty,
+          forums = immutable.Seq.empty,
           releaseNotes = None,
-          snapshots    = None,
+          snapshots = None,
           levels = List(
-            Level(ReadinessLevel.Incubating,
-                  LocalDate.of(2018, 11, 22),
-                  "0.18",
-                  None,
-                  Some("Community rocks this module"))),
-        ))
+            Level(
+              ReadinessLevel.Incubating,
+              LocalDate.of(2018, 11, 22),
+              "0.18",
+              None,
+              Some("Community rocks this module")
+            )
+          )
+        )
+      )
     }
 
     "support history" in {
@@ -150,24 +154,27 @@ class ProjectInfoSpec extends WordSpec with Matchers {
       ProjectInfo(name, conf) should be(
         ProjectInfo(
           "core",
-          title         = "The core project",
+          title = "The core project",
           scalaVersions = List("2.12", "2.13"),
-          jdkVersions   = List("OpenJDK 8"),
+          jdkVersions = List("OpenJDK 8"),
           Some("alpakka.core"),
-          issues       = Some(Link("https://github.com/akka/alpakka/labels/p:core", None)),
-          apiDocs      = immutable.Seq.empty,
-          forums       = immutable.Seq.empty,
+          issues = Some(Link("https://github.com/akka/alpakka/labels/p:core", None)),
+          apiDocs = immutable.Seq.empty,
+          forums = immutable.Seq.empty,
           releaseNotes = None,
-          snapshots    = None,
+          snapshots = None,
           levels = List(
             Level(ReadinessLevel.Supported, LocalDate.of(2018, 12, 12), "0.21", None, None),
-            Level(ReadinessLevel.Incubating,
-                  LocalDate.of(2018, 11, 22),
-                  "0.18",
-                  None,
-                  Some("Community rocks this module"))
+            Level(
+              ReadinessLevel.Incubating,
+              LocalDate.of(2018, 11, 22),
+              "0.18",
+              None,
+              Some("Community rocks this module")
+            )
           )
-        ))
+        )
+      )
     }
 
     "support API docs as list" in {
@@ -209,24 +216,29 @@ class ProjectInfoSpec extends WordSpec with Matchers {
       ProjectInfo(name, conf) should be(
         ProjectInfo(
           "core",
-          title         = "The core project",
+          title = "The core project",
           scalaVersions = List("2.12", "2.13"),
-          jdkVersions   = List("OpenJDK 8"),
+          jdkVersions = List("OpenJDK 8"),
           Some("alpakka.core"),
           issues = Some(Link("https://github.com/akka/alpakka/labels/p:core", None)),
           apiDocs = List(
-            Link("https://developer.lightbend.com/docs/api/alpakka/current/akka/stream/alpakka/index.html",
-                 Some("Javadoc")),
-            Link("https://developer.lightbend.com/docs/api/alpakka/current/akka/stream/alpakka/index.html",
-                 Some("Scaladoc"))
+            Link(
+              "https://developer.lightbend.com/docs/api/alpakka/current/akka/stream/alpakka/index.html",
+              Some("Javadoc")
+            ),
+            Link(
+              "https://developer.lightbend.com/docs/api/alpakka/current/akka/stream/alpakka/index.html",
+              Some("Scaladoc")
+            )
           ),
-          forums       = immutable.Seq.empty,
+          forums = immutable.Seq.empty,
           releaseNotes = None,
-          snapshots    = None,
+          snapshots = None,
           levels = List(
             Level(ReadinessLevel.Supported, LocalDate.of(2018, 12, 12), "0.21", None, None)
           )
-        ))
+        )
+      )
     }
 
     "support forums as list" in {
@@ -268,22 +280,23 @@ class ProjectInfoSpec extends WordSpec with Matchers {
       ProjectInfo(name, conf) should be(
         ProjectInfo(
           "core",
-          title         = "The core project",
+          title = "The core project",
           scalaVersions = List("2.12", "2.13"),
-          jdkVersions   = List("OpenJDK 8"),
+          jdkVersions = List("OpenJDK 8"),
           Some("alpakka.core"),
-          issues  = Some(Link("https://github.com/akka/alpakka/labels/p:core", None)),
+          issues = Some(Link("https://github.com/akka/alpakka/labels/p:core", None)),
           apiDocs = immutable.Seq.empty,
           forums = List(
             Link("https://discuss.lightbend.com/c/akka/", Some("Lightbend Discuss")),
             Link("https://gitter.im/akka/alpakka-kafka", Some("akka/alpakka-kafka Gitter channel"))
           ),
           releaseNotes = None,
-          snapshots    = None,
+          snapshots = None,
           levels = List(
             Level(ReadinessLevel.Supported, LocalDate.of(2018, 12, 12), "0.21", None, None)
           )
-        ))
+        )
+      )
     }
 
     "support snapshot link" in {
@@ -315,22 +328,26 @@ class ProjectInfoSpec extends WordSpec with Matchers {
       ProjectInfo(name, conf) should be(
         ProjectInfo(
           "core",
-          title         = "The core project",
+          title = "The core project",
           scalaVersions = List("2.12", "2.13"),
-          jdkVersions   = List("OpenJDK 8"),
-          jpmsName      = None,
-          issues        = None,
-          apiDocs       = immutable.Seq.empty,
-          forums        = immutable.Seq.empty,
-          releaseNotes  = None,
+          jdkVersions = List("OpenJDK 8"),
+          jpmsName = None,
+          issues = None,
+          apiDocs = immutable.Seq.empty,
+          forums = immutable.Seq.empty,
+          releaseNotes = None,
           snapshots = Some(
-            Link("https://bintray.com/akka/snapshots/alpakka-kafka/1.0-M1%2B44-9f512541",
-                 Some("Snapshots are published after every commit on master"),
-                 newTab = false)),
+            Link(
+              "https://bintray.com/akka/snapshots/alpakka-kafka/1.0-M1%2B44-9f512541",
+              Some("Snapshots are published after every commit on master"),
+              newTab = false
+            )
+          ),
           levels = List(
             Level(ReadinessLevel.Supported, LocalDate.of(2018, 12, 12), "0.21", None, None)
           )
-        ))
+        )
+      )
     }
 
   }


### PR DESCRIPTION
Since the version of scalafmt in tihs project is very old, this PR updates to the latest version of scalafmt with the equivalent options. Note that since the version of scalafmt is so old, there were many more changes incorporated in scalafmt which explains the large diff thats happening in applying scalafmt. If you want to change the scalafmt configuration then let me know and I can rebase the PR with the changes.