### PR TITLE
Add github-actions scalafmt check

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,26 @@
+name: Scalafmt
+
+on:
+  pull_request:
+    branches: ['**']
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    name: Code is formatted
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v1
+        with:
+          version: '3.4.3'

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,6 @@ Compile / doc / sources                := Seq.empty
 Compile / packageDoc / publishArtifact := false
 
 enablePlugins(AutomateHeaderPlugin)
-scalafmtOnCompile := true
 
 // Disable publish for now
 ThisBuild / githubWorkflowPublishTargetBranches := Seq()


### PR DESCRIPTION
Adds a github-actions check to see that the entire project is formatted. Since this is separate from `ci.yml`, it will run in parallel to the main build and it also doesn't require the project to be compiled/load SBT since it uses scalafmt-native (in other words its very fast).

I have also removed `scalafmtOnCompile := true`. I personally hate this setting because it causes a lot of issues with IDE's/editors due to memory/file system divergence and this check ensures that people can't accidentally merge unformatted code anyways.