### PR TITLE
Update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,8 @@ name             := "sbt-paradox-project-info"
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.4.3")
 
 libraryDependencies ++= Seq(
-  "com.typesafe"   % "config"    % "1.3.3",
-  "org.scalatest" %% "scalatest" % "3.0.8" % Test // ApacheV2
+  "com.typesafe"   % "config"    % "1.4.2",
+  "org.scalatest" %% "scalatest" % "3.2.9" % Test // ApacheV2
 )
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
-addSbtPlugin("com.dwijnand"      % "sbt-dynver"         % "4.0.0")
-addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.6.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.6.5")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.4.6")
 addSbtPlugin("com.codecommit"    % "sbt-github-actions" % "0.14.2")
 addSbtPlugin("com.github.sbt"    % "sbt-ci-release"     % "1.5.10")

--- a/src/test/scala/com/lightbend/paradox/projectinfo/ProjectInfoSpec.scala
+++ b/src/test/scala/com/lightbend/paradox/projectinfo/ProjectInfoSpec.scala
@@ -17,14 +17,13 @@
 package com.lightbend.paradox.projectinfo
 
 import java.time.LocalDate
-
 import com.typesafe.config.ConfigFactory
-import org.scalatest.WordSpec
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.collection.immutable
 
-class ProjectInfoSpec extends WordSpec with Matchers {
+class ProjectInfoSpec extends AnyWordSpec with Matchers {
 
   "Level" should {
     "read from config" in {

--- a/src/test/scala/com/lightbend/paradox/projectinfo/ReadinessLevelSpec.scala
+++ b/src/test/scala/com/lightbend/paradox/projectinfo/ReadinessLevelSpec.scala
@@ -16,11 +16,10 @@
 
 package com.lightbend.paradox.projectinfo
 
-import org.scalatest.FlatSpec
+import ReadinessLevel.*
+import org.scalatest.flatspec.AnyFlatSpec
 
-import ReadinessLevel._
-
-class ReadinessLevelSpec extends FlatSpec {
+class ReadinessLevelSpec extends AnyFlatSpec {
 
   "String values" should "read correctly" in {
     val values = Map(


### PR DESCRIPTION
This PR updates dependencies. Note that `sbt-dynver` is removed because its provided transitively by sbt-ci-release. The changes in tests are due to breaking changes in latest ScalaTest