### PR TITLE
Fix sonatype scoped setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ ThisBuild / publishTo              := sonatypePublishTo.value
 ThisBuild / test / publishArtifact := false
 ThisBuild / pomIncludeRepository   := (_ => false)
 ThisBuild / Compile / doc / sources := Seq() // See https://github.com/xerial/sbt-sonatype/issues/30#issuecomment-342532067
-ThisBuild / sonatypeProfileName := "com.lightbend"
+sonatypeProfileName := "com.lightbend"
 
 ThisBuild / githubWorkflowJavaVersions := List(
   JavaSpec.temurin("8"),


### PR DESCRIPTION
Gotta love SBT sometimes

```
2022-03-11 14:19:44.557Z error [Sonatype] [MISSING_PROFILE] Profile com.lightbend.paradox is not found. Check your sonatypeProfileName setting in build.sbt  - (Sonatype.scala:440)
````