### PR TITLE
Remove publishArtifact := false

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,10 +37,6 @@ developers += Developer(
 organizationName := "Lightbend Inc."
 startYear        := Some(2018)
 
-// no API docs
-Compile / doc / sources                := Seq.empty
-Compile / packageDoc / publishArtifact := false
-
 enablePlugins(AutomateHeaderPlugin)
 
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
@@ -62,8 +58,7 @@ ThisBuild / publishMavenStyle      := true
 ThisBuild / publishTo              := sonatypePublishTo.value
 ThisBuild / test / publishArtifact := false
 ThisBuild / pomIncludeRepository   := (_ => false)
-ThisBuild / Compile / doc / sources := Seq() // See https://github.com/xerial/sbt-sonatype/issues/30#issuecomment-342532067
-sonatypeProfileName := "com.lightbend"
+sonatypeProfileName                := "com.lightbend"
 
 ThisBuild / githubWorkflowJavaVersions := List(
   JavaSpec.temurin("8"),


### PR DESCRIPTION
So asked around in the Scala discord communities sbt chat to get help on this and they are quite sure that

```sbt
Compile / packageDoc / publishArtifact := false
```

Is whats causing the isuse. Even if you don't have any apidocs, having this setting for published artifacts in sonatype causes problems. Other projects such also don't have this setting (see https://github.com/lightbend/sbt-paradox-apidoc/blob/master/build.sbt)

References https://github.com/lightbend/sbt-paradox-project-info/issues/31