### PR TITLE
Make ReadinessLevel's configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,6 @@ project-info {
         url: "https://gitter.im/akka/alpakka-kafka"
       }
     ]
-    levels: [
-      {
-        readiness: Supported
-        since: "2018-11-22"
-        since-version: "0.22"
-      }
-      {
-        readiness: Incubating
-        since: "2018-08-22"
-        since-version: "0.16"
-        note: "Community rocks this module"
-      }
-    ]
   }
 }
 ```
@@ -82,6 +69,85 @@ The quick brown fox...
 
 ```
 [Example](https://github.com/lightbend/sbt-paradox-project-info/blob/master/src/sbt-test/project-info/happy-path/src/main/paradox/index.md)
+
+### Readiness Levels
+
+Readiness levels is a convenient way to show the support for different projects. In order to use readiness levels you
+first need to specify what they mean and how to render them, i.e.
+
+```sbt
+import com.lightbend.paradox.projectinfo._
+import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys._
+
+readinessLevels ++= Map(
+  "Supported" -> new ReadinessLevel {
+    val name = "<b>This project is supported</b>"
+  },
+  "NotSupported" -> new ReadinessLevel {
+    val name = "<b>This project is not supported</b>"
+  }
+)
+```
+
+Then in your `project/project-info.conf` you can specify these readiness levels using the `levels` config path, i.e.
+
+```hocon
+project-info {
+  # version is overridden from the `projectInfoVersion` key (which defaults to sbt's project version)
+  version: "current"
+  scala-versions: ["2.12", "2.13"]
+  jdk-versions: ["OpenJDK 8"]
+  core {
+    title: "The core project"
+    // if undefined, sbt's crossScalaVersions are used
+    scala-versions: ${project-info.scala-versions}
+    jdk-versions: ${project-info.jdk-versions}
+    jpms-name: "alpakka.core"
+    snapshots: {
+      text: "Snapshots are available"
+      url: "snapshots.html"
+      new-tab: false
+    }
+    issues: {
+      url: "https://github.com/lightbend/sbt-paradox-project-info/issues"
+      text: "Github issues"
+    }
+    release-notes: {
+      url: "https://github.com/lightbend/sbt-paradox-project-info/releases"
+      text: "Github releases"
+    }
+    api-docs: [
+      {
+        text: "Scaladoc"
+        url: "https://developer.lightbend.com/docs/api/alpakka/"${project-info.version}"/akka/stream/alpakka/index.html"
+      }
+    ]
+    forums: [
+      {
+        text: "Lightbend Discuss"
+        url: "https://discuss.lightbend.com/c/akka/"
+      }
+      {
+        text: "akka/alpakka-kafka Gitter channel"
+        url: "https://gitter.im/akka/alpakka-kafka"
+      }
+    ]
+    levels: [
+      {
+        readiness: Supported
+        since: "2018-11-22"
+        since-version: "0.22"
+      }
+      {
+        readiness: NotSupported
+        since: "2018-08-22"
+        since-version: "0.16"
+        note: "Alpha level of module"
+      }
+    ]
+  }
+}
+```
 
 ## License
 

--- a/src/main/scala/com/lightbend/paradox/projectinfo/ParadoxProjectInfoPluginKeys.scala
+++ b/src/main/scala/com/lightbend/paradox/projectinfo/ParadoxProjectInfoPluginKeys.scala
@@ -20,6 +20,8 @@ import sbt._
 
 trait ParadoxProjectInfoPluginKeys {
   val projectInfoVersion = settingKey[String]("The version/revision propagated into `project-info.version`.")
+  val readinessLevels =
+    settingKey[Map[String, ReadinessLevel]]("The referenced readiness-levels when using levels")
 }
 
 object ParadoxProjectInfoPluginKeys extends ParadoxProjectInfoPluginKeys

--- a/src/main/scala/com/lightbend/paradox/projectinfo/ProjectInfoDirective.scala
+++ b/src/main/scala/com/lightbend/paradox/projectinfo/ProjectInfoDirective.scala
@@ -23,13 +23,16 @@ import com.typesafe.config.Config
 import org.pegdown.Printer
 import org.pegdown.ast.{DirectiveNode, Visitor}
 
-class ProjectInfoDirective(config: Config, moduleToSbtValues: String => SbtValues)
-    extends LeafBlockDirective("project-info") {
+class ProjectInfoDirective(
+    config: Config,
+    moduleToSbtValues: String => SbtValues,
+    readinessLevelsMap: Map[String, ReadinessLevel]
+) extends LeafBlockDirective("project-info") {
   def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit = {
     val projectId = node.attributes.value("projectId")
     if (config.hasPath(projectId)) {
       val module = config.getConfig(projectId)
-      val data   = SbtAndProjectInfo(moduleToSbtValues(projectId), ProjectInfo(projectId, module))
+      val data   = SbtAndProjectInfo(moduleToSbtValues(projectId), ProjectInfo(projectId, readinessLevelsMap, module))
       ProjectInfoDirective.renderInfo(printer, data)
     } else throw new RuntimeException(s"project-info.conf does not contain `$projectId`")
   }

--- a/src/test/scala/com/lightbend/paradox/projectinfo/ProjectInfoSpec.scala
+++ b/src/test/scala/com/lightbend/paradox/projectinfo/ProjectInfoSpec.scala
@@ -36,7 +36,9 @@ class ProjectInfoSpec extends AnyWordSpec with Matchers {
           |}
         """.stripMargin
       val c = ConfigFactory.parseString(in).getConfig("level")
-      Level(c) should be(Level(ReadinessLevel.Incubating, LocalDate.of(2018, 11, 22), "0.12", None, None))
+      Level(c, SampleReadinessLevels.values) should be(
+        Level(SampleReadinessLevels.Incubating, LocalDate.of(2018, 11, 22), "0.12", None, None)
+      )
     }
   }
 
@@ -51,7 +53,7 @@ class ProjectInfoSpec extends AnyWordSpec with Matchers {
           |}
         """.stripMargin
       val c = ConfigFactory.parseString(in).getConfig("core")
-      ProjectInfo("core", c) should be(
+      ProjectInfo("core", SampleReadinessLevels.values, c) should be(
         ProjectInfo(
           "core",
           "core",
@@ -93,7 +95,7 @@ class ProjectInfoSpec extends AnyWordSpec with Matchers {
       val c    = ConfigFactory.parseString(in).getConfig("project-info")
       val name = "core"
       val conf = c.getConfig(name)
-      ProjectInfo(name, conf) should be(
+      ProjectInfo(name, SampleReadinessLevels.values, conf) should be(
         ProjectInfo(
           "core",
           title = "The core project",
@@ -107,7 +109,7 @@ class ProjectInfoSpec extends AnyWordSpec with Matchers {
           snapshots = None,
           levels = List(
             Level(
-              ReadinessLevel.Incubating,
+              SampleReadinessLevels.Incubating,
               LocalDate.of(2018, 11, 22),
               "0.18",
               None,
@@ -150,7 +152,7 @@ class ProjectInfoSpec extends AnyWordSpec with Matchers {
       val c    = ConfigFactory.parseString(in).resolve().getConfig("project-info")
       val name = "core"
       val conf = c.getConfig(name)
-      ProjectInfo(name, conf) should be(
+      ProjectInfo(name, SampleReadinessLevels.values, conf) should be(
         ProjectInfo(
           "core",
           title = "The core project",
@@ -163,9 +165,9 @@ class ProjectInfoSpec extends AnyWordSpec with Matchers {
           releaseNotes = None,
           snapshots = None,
           levels = List(
-            Level(ReadinessLevel.Supported, LocalDate.of(2018, 12, 12), "0.21", None, None),
+            Level(SampleReadinessLevels.Supported, LocalDate.of(2018, 12, 12), "0.21", None, None),
             Level(
-              ReadinessLevel.Incubating,
+              SampleReadinessLevels.Incubating,
               LocalDate.of(2018, 11, 22),
               "0.18",
               None,
@@ -212,7 +214,7 @@ class ProjectInfoSpec extends AnyWordSpec with Matchers {
       val c    = ConfigFactory.parseString(in).resolve().getConfig("project-info")
       val name = "core"
       val conf = c.getConfig(name)
-      ProjectInfo(name, conf) should be(
+      ProjectInfo(name, SampleReadinessLevels.values, conf) should be(
         ProjectInfo(
           "core",
           title = "The core project",
@@ -234,7 +236,7 @@ class ProjectInfoSpec extends AnyWordSpec with Matchers {
           releaseNotes = None,
           snapshots = None,
           levels = List(
-            Level(ReadinessLevel.Supported, LocalDate.of(2018, 12, 12), "0.21", None, None)
+            Level(SampleReadinessLevels.Supported, LocalDate.of(2018, 12, 12), "0.21", None, None)
           )
         )
       )
@@ -276,7 +278,7 @@ class ProjectInfoSpec extends AnyWordSpec with Matchers {
       val c    = ConfigFactory.parseString(in).resolve().getConfig("project-info")
       val name = "core"
       val conf = c.getConfig(name)
-      ProjectInfo(name, conf) should be(
+      ProjectInfo(name, SampleReadinessLevels.values, conf) should be(
         ProjectInfo(
           "core",
           title = "The core project",
@@ -292,7 +294,7 @@ class ProjectInfoSpec extends AnyWordSpec with Matchers {
           releaseNotes = None,
           snapshots = None,
           levels = List(
-            Level(ReadinessLevel.Supported, LocalDate.of(2018, 12, 12), "0.21", None, None)
+            Level(SampleReadinessLevels.Supported, LocalDate.of(2018, 12, 12), "0.21", None, None)
           )
         )
       )
@@ -324,7 +326,7 @@ class ProjectInfoSpec extends AnyWordSpec with Matchers {
       val c    = ConfigFactory.parseString(in).resolve().getConfig("project-info")
       val name = "core"
       val conf = c.getConfig(name)
-      ProjectInfo(name, conf) should be(
+      ProjectInfo(name, SampleReadinessLevels.values, conf) should be(
         ProjectInfo(
           "core",
           title = "The core project",
@@ -343,7 +345,7 @@ class ProjectInfoSpec extends AnyWordSpec with Matchers {
             )
           ),
           levels = List(
-            Level(ReadinessLevel.Supported, LocalDate.of(2018, 12, 12), "0.21", None, None)
+            Level(SampleReadinessLevels.Supported, LocalDate.of(2018, 12, 12), "0.21", None, None)
           )
         )
       )

--- a/src/test/scala/com/lightbend/paradox/projectinfo/SampleReadinessLevels.scala
+++ b/src/test/scala/com/lightbend/paradox/projectinfo/SampleReadinessLevels.scala
@@ -16,21 +16,24 @@
 
 package com.lightbend.paradox.projectinfo
 
-import ReadinessLevel.*
-import org.scalatest.flatspec.AnyFlatSpec
-
-class ReadinessLevelSpec extends AnyFlatSpec {
-
-  "String values" should "read correctly" in {
-    val values = Map(
-      "EndOfLife" -> EndOfLife,
-      "Supported" -> Supported,
-      "CommunityDriven" -> CommunityDriven,
-      "Incubating" -> Incubating
-    )
-    for {
-      (s, expected) <- values
-    } assert(ReadinessLevel.fromString(s) === expected)
+object SampleReadinessLevels {
+  case object EndOfLife extends ReadinessLevel {
+    val name = "End of life"
+  }
+  case object Supported extends ReadinessLevel {
+    val name = "Supported"
+  }
+  case object CommunityDriven extends ReadinessLevel {
+    val name = "Community Driven"
+  }
+  case object Incubating extends ReadinessLevel {
+    val name = "Incubating"
   }
 
+  val values = Map(
+    "EndOfLife" -> EndOfLife,
+    "Supported" -> Supported,
+    "CommunityDriven" -> CommunityDriven,
+    "Incubating" -> Incubating
+  )
 }


### PR DESCRIPTION
Removes Lightbend hardcoded values for `readinessLevel`'s and allows them to be configurable. This is done by adding a new sbt key called `readinessLevels` which is a `Map[String, ReadinessLevel]` where the `String` is the config key in `project-info.conf` and the value is a Scala type that implements `ReadinessLevel`. I decided to make this confgurable via sbt settings instead of typesafe config because the typesafe config inheritance doesn't via nested projects doesn't work with sbt plugins (ontop of this defining the html rendering via `name` in hoconf is not that nice).

In order to test that this is actually working properly, I created a sample https://github.com/mdedetrich/sbt-paradox-lightbend-project-info and using `sbt localPublish` along with temporarily setting the version to `-SNAPSHOT` I republished https://github.com/akka/akka-paradox locally to test it with https://github.com/akka/alpakka `docs/makeSite`. Note that https://github.com/mdedetrich/sbt-paradox-lightbend-project-info implements the sbt-plugin to automatically trigger when you include it as a dependency (the alternative is to use `noTrigger` which means you manually have to enable it with `.enablePlugins(LightbendParadoxInfoPlugin)`).

This means that once this pull request and released the following things to need to be done

* Create a new project such as https://github.com/mdedetrich/sbt-paradox-lightbend-project-info that uses the newly released sbt-paradox-project-info. Note that you can just copy https://github.com/mdedetrich/sbt-paradox-lightbend-project-info if you wish, its pretty much ready to go and just needs to be put under lightbend org + released
* Update https://github.com/akka/akka-paradox to point to `sbt-paradox-lightbend-project-info` instead of `sbt-paradox-project-info` and make a new release
* Gradually update akka/lightbend projects to use the newly released `akka-paradox`. This is very easy due to the fact that https://github.com/mdedetrich/sbt-paradox-lightbend-project-info automatically triggers when you include it as a dependency (even as a transitive one) so all you need to do is to just bump the value of a single dependency in `project/plugins.sbt`.

Resolves: https://github.com/lightbend/sbt-paradox-project-info/issues/17