### PR TITLE
Upgrade dependencies to move away from repo.scala-sbt.org

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ crossSbtVersions := List("1.4.9")
 organization     := "com.lightbend.paradox"
 name             := "sbt-paradox-project-info"
 
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.10.3")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.10.6")
 
 libraryDependencies ++= Seq(
   "com.typesafe"   % "config"    % "1.4.2",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.6.5")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.4.6")
 addSbtPlugin("com.codecommit"    % "sbt-github-actions" % "0.14.2")
-addSbtPlugin("com.github.sbt"    % "sbt-ci-release"     % "1.5.11")
+addSbtPlugin("com.github.sbt"    % "sbt-ci-release"     % "1.5.12")


### PR DESCRIPTION
I started to block [repo.scala-sbt.org](http://repo.scala-sbt.org/) and [repo.typesafe.com](http://repo.typesafe.com/) in my `/etc/hosts`. 

* sbt-paradox 0.10.5 still hosted on repo.scala-sbt.org, migrated to maven central with latest 0.10.6
* sbt-ci-release 1.5.11 pull in older sbt-dynver release still hosted on repo.scala-sbt.org, latest version fixed that.

After merging this can you cut a 3.0.1 release? Thanks!

- Blocks https://github.com/lightbend/sbt-paradox-lightbend-project-info/pull/10